### PR TITLE
quote username and password to avoid shell parse errors

### DIFF
--- a/features/rhsm.py
+++ b/features/rhsm.py
@@ -21,7 +21,7 @@ class RHSM(Base):
         repos += ' --enable="rhel-7-fast-datapath-rpms"'
         repos += ' --enable="rhel-7-server-ose-3.%s-rpms"' % (self.deployment.version.major)
 
-        connection.execute("/sbin/subscription-manager register --username=%s --password=%s" % (u, p), True)
+        connection.execute("/sbin/subscription-manager register --username=\"%s\" --password=\"%s\"" % (u, p), True)
         connection.execute("/sbin/subscription-manager attach --pool=%s" % pool, True)
         connection.execute('/sbin/subscription-manager repos --disable="*"', True)
         connection.execute('/sbin/subscription-manager repos %s' % repos, True)


### PR DESCRIPTION
Without this, if your password contains special characters such as `)` or `(` it can interfere with shell argument parsing.

```
INFO:Feature(RHSM):Register subscriptions
DEBUG:SSH(104.196.97.215):Executing: sudo bash -c '/sbin/subscription-manager register --username=xxxx --password=xxxxx'
DEBUG:paramiko.transport:[chan 0] Max packet in: 32768 bytes
DEBUG:paramiko.transport:[chan 0] Max packet out: 32768 bytes
DEBUG:paramiko.transport:Secsh channel 0 opened.
DEBUG:paramiko.transport:[chan 0] Sesch channel 0 request ok
DEBUG:paramiko.transport:[chan 0] EOF received (0)
DEBUG:paramiko.transport:[chan 0] EOF sent (0)
DEBUG:SSH(104.196.97.215):Exit code: 1
DEBUG:SSH(104.196.97.215):STDOUT:
DEBUG:SSH(104.196.97.215):STDERR: bash: -c: line 0: syntax error near unexpected token `)'
bash: -c: line 0: `/sbin/subscription-manager register --username=xxxxx --password=xxxxxxxxxxx'
```
